### PR TITLE
Support router basepath

### DIFF
--- a/.config/webpack/common.config.js
+++ b/.config/webpack/common.config.js
@@ -3,6 +3,15 @@ const {resolve} = require('path')
 const {TsConfigPathsPlugin} = require('awesome-typescript-loader')
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin')
 
+const ENV_VARS = [
+  'SYNCANO_PROJECT_INSTANCE',
+  'SENTRY_URL',
+  'PUBLIC_URL',
+  'TRACKJS_KEY',
+  'LOCAL_STORAGE_KEY',
+  'ROUTER_BASEPATH',
+]
+
 module.exports = {
   context: resolve(__dirname, '../../workspaces'),
   output: {
@@ -70,22 +79,11 @@ module.exports = {
         }
       }
     }),
-    new webpack.DefinePlugin({
-      'process.env.SYNCANO_PROJECT_INSTANCE': JSON.stringify(
-        process.env.SYNCANO_PROJECT_INSTANCE
-      ),
-      'process.env.SENTRY_URL': JSON.stringify(
-        process.env.SENTRY_URL
-      ),
-      'process.env.PUBLIC_URL': JSON.stringify(
-        process.env.PUBLIC_URL
-      ),
-      'process.env.TRACKJS_KEY': JSON.stringify(
-        process.env.TRACKJS_KEY
-      ),
-      'process.env.LOCAL_STORAGE_KEY': JSON.stringify(
-        process.env.LOCAL_STORAGE_KEY
-      )
-    })
+    new webpack.DefinePlugin(
+      ENV_VARS.reduce((all, name) => ({
+        ...all,
+        [`process.env.${name}`]: JSON.stringify(process.env[name])
+      }), {})
+    )
   ]
 }

--- a/.envrc.example
+++ b/.envrc.example
@@ -1,3 +1,6 @@
+# Render a root router in sub directory
+export ROUTER_BASEPATH=
+
 #  Syncano instance attached to project
 export SYNCANO_PROJECT_INSTANCE=
 

--- a/README.md
+++ b/README.md
@@ -57,3 +57,11 @@ To setup error tracking, set `SENTRY_URL` environment variable to your sentry pr
 ```sh
 SENTRY_URL=https://XXXXXXXXX@sentry.io/XXXXXXX
 ```
+
+## Render application at sub directory
+
+To render app at sub directory, set `ROUTER_BASEPATH` environment variable the sub directory name.
+
+```sh
+ROUTER_BASEPATH=/sub-directory-name
+```

--- a/workspaces/shared/components/index.tsx
+++ b/workspaces/shared/components/index.tsx
@@ -1,10 +1,3 @@
-import {Link as RouterLink} from '@reach/router'
-import {Block} from '@shared/components/block'
-import styled from '@shared/utils/styled'
-import * as React from 'react'
-const StyledLink = styled(Block)`display: inline-block;`
-export const Link = (props) => <StyledLink as={RouterLink} {...props} />
-
 export {Head} from '@shared/components/head'
 export {InputList} from '@shared/components/input-list'
 export {Message} from '@shared/components/message'
@@ -17,3 +10,4 @@ export {Icon} from '@shared/components/icon'
 export {Spinner} from '@shared/components/spinner'
 export {Modal} from '@shared/components/modal'
 export {Label} from '@shared/components/label'
+export {Link} from '@shared/components/link'

--- a/workspaces/shared/components/link.tsx
+++ b/workspaces/shared/components/link.tsx
@@ -1,0 +1,14 @@
+import {Link as RouterLink} from '@reach/router'
+import {Block} from '@shared/components/block'
+import {ROUTER_BASEPATH} from '@shared/config'
+import styled from '@shared/utils/styled'
+import * as React from 'react'
+
+const StyledLink = styled(Block)`display: inline-block;`
+export const Link = (props) => {
+  const to = props.to ? `${ROUTER_BASEPATH}/${props.to.replace(/^\//, '')}` : props.to
+
+  return (
+    <StyledLink as={RouterLink} {...props} to={to} />
+  )
+}

--- a/workspaces/shared/config.tsx
+++ b/workspaces/shared/config.tsx
@@ -7,6 +7,7 @@ export const SENTRY_URL = process.env.SENTRY_URL
 export const TRACKJS_KEY = process.env.TRACKJS_KEY
 export const LOCAL_STORAGE_KEY = process.env.LOCAL_STORAGE_KEY
 export const SYNCANO_PROJECT_INSTANCE = process.env.SYNCANO_PROJECT_INSTANCE
+export const ROUTER_BASEPATH = process.env.ROUTER_BASEPATH || ''
 export const UI: Theme = {
   spacing: spacing(8),
   radius: '5px',

--- a/workspaces/website/config.tsx
+++ b/workspaces/website/config.tsx
@@ -1,0 +1,1 @@
+export const ROUTER_BASEPATH = process.env.ROUTER_BASEPATH || ''

--- a/workspaces/website/routes.tsx
+++ b/workspaces/website/routes.tsx
@@ -1,4 +1,5 @@
 import {Router} from '@reach/router'
+import {ROUTER_BASEPATH} from '@shared/config'
 import {loadable} from '@shared/utils/loadable'
 import '@shared/utils/normalize'
 import '@website/styles'
@@ -17,11 +18,11 @@ export interface Props extends WithStore {}
 export class Routes extends React.Component<Props> {
   render() {
     return (
-      <Router>
+      <Router basepath={ROUTER_BASEPATH}>
         <routes.Index path="/" />
-        <routes.Auth.Login path="auth/login" />
-        <routes.Auth.Register path="auth/register" />
-        <routes.Auth.Logout path="auth/logout" />
+        <routes.Auth.Login path="/auth/login" />
+        <routes.Auth.Register path="/auth/register" />
+        <routes.Auth.Logout path="/auth/logout" />
         <routes.Missing default />
       </Router>
     )


### PR DESCRIPTION
To render app at sub directory, add `ROUTER_BASEPATH` to `.envrc`:

```sh
export ROUTER_BASEPATH=/sub-directory-name
```

Resolves #11 